### PR TITLE
修复Windows下中国流量分流失效问题

### DIFF
--- a/src/china/mod.rs
+++ b/src/china/mod.rs
@@ -9,7 +9,7 @@ use treebitmap::IpLookupTable;
 /// List of all Chinese domains.
 static DOMAINS: Lazy<HashSet<String>> = Lazy::new(|| {
     let ss = include_str!("china-domains.txt");
-    ss.split('\n')
+    ss.split_ascii_whitespace()
         .filter(|v| v.len() > 1)
         .map(|v| v.to_string())
         .collect()


### PR DESCRIPTION
windows下使用.split('\n')处理china-domains.txt会造成字符串末尾出现\r，导致域名匹配失效，改为使用.split_ascii_whitespace()处理。