### PR TITLE
（這是個 PoC 用於表示實現思路）避免在 too many requests 或者 network unreachable 的時候 丟失節點信息：使得 geph4-client 只有在成功從 binder 獲取到登錄信息的時候，才會覆蓋更新本地緩存 ~/.config/geph4-credentials/ 

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use structopt::StructOpt;
 
-use crate::config::{get_cached_binder_client, AuthOpt, CommonOpt};
+use crate::config::{user_id_hex, get_cached_binder_client, AuthOpt, CommonOpt};
 
 #[derive(Debug, StructOpt, Deserialize, Serialize, Clone)]
 pub struct SyncOpt {
@@ -26,15 +26,36 @@ pub async fn main_sync(opt: SyncOpt) -> anyhow::Result<()> {
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub async fn sync_json(opt: SyncOpt) -> anyhow::Result<String> {
-    if opt.force {
-        // clear the entire directory, baby!
-        for _ in 0..100 {
-            let _ = std::fs::remove_dir_all(&opt.auth.credential_cache);
-        }
-        // anyhow::bail!("oh")
+    let orig_dbpath = opt.auth.credential_cache.clone();
+
+    // this will leave original status unmodified, and ONLY overwriting if success to get next state.
+    // so (in the case) if we unable to fetch network info from binder, this will make the program able to fallback to last one
+    let next_dbpath = {
+        let mut p = orig_dbpath.clone();
+        assert!(
+            // that do something like this: /tmp/cache -> /tmp/cache.next-state-123
+            p.set_extension(
+                format!("next-state-{}", fastrand::u32(..))
+            )
+        );
+        p
+    };
+
+    println!("called: next-state-dir: {:?}", &next_dbpath);
+    println!("orig-state: {:?}", &orig_dbpath);
+
+    // make sure next state is empty
+    for _ in 0..100 {
+        let _ = std::fs::remove_dir_all(&next_dbpath);
     }
 
-    let binder_client = get_cached_binder_client(&opt.common, &opt.auth)?;
+
+    let binder_client = get_cached_binder_client(&opt.common, &{
+        // create a temp context for binder_client only
+        let mut opt_auth = opt.auth.clone();
+        opt_auth.credential_cache = next_dbpath.clone();
+        opt_auth
+    })?;
     let master = binder_client.get_summary().await?;
     let user = binder_client.get_auth_token().await?.0;
     let exits = master
@@ -56,6 +77,29 @@ pub async fn sync_json(opt: SyncOpt) -> anyhow::Result<String> {
             load: exit.load,
         })
         .collect_vec();
+
+    // in this case, we got latest network info from binder:
+    // so use ".next.state" to overwrite the real cache path.
+    let id = user_id_hex(&opt.auth);
+    std::fs::rename({
+        let mut p = orig_dbpath.clone();
+        p.push(&id);
+        for _ in 0..100 { let _ = std::fs::remove_dir_all(&p); }
+
+        let mut p = next_dbpath.clone();
+        p.push(&id);
+        p
+    }, {
+        let mut p = orig_dbpath.clone();
+        p.push(id);
+        p
+    })?;
+
+    // clean temp directory to avoid dropping junk to local disk
+    for _ in 0..100 {
+        let _ = std::fs::remove_dir_all(&next_dbpath);
+    }
+
     Ok(format!(
         "{{\"exits\": {}, \"user\": {}, \"version\": {:?}}}",
         serde_json::to_string(&exits)?,


### PR DESCRIPTION
現在的 sync --force 的邏輯很不合理，是先刪除了 緩存目錄，然後連接 binder 更新。所以如果連接不上 binder 的時候就會 丟失上一次 sync 的信息

簡單來說，這個例子是在先創建一個新的目錄來表示 “最新狀態”，然後只有在 geph4-client sync 命令執行成功時才會把這個 state 更新到 原本的儲存位置。
這樣一旦互聯網斷開、用戶頻繁請求導致 429，或者是因爲 binder 下線  導致無法更新的時候，那麼不會改動上一次保存的 json 文件 ，所以用戶可以嘗試使用最後一次 sync 得到的信息