### PR TITLE
Update dependencies to address security vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2307,9 +2307,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -6062,7 +6062,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6276,6 +6276,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6372,11 +6378,12 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+checksum = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e"
 dependencies = [
- "wasm-bindgen",
+ "redox_syscall 0.4.1",
+ "wasite",
  "web-sys",
 ]
 


### PR DESCRIPTION
### Description

This Pull Request updates several dependencies to their newer versions, addressing the vulnerabilities reported by `cargo audit`. The primary goal is to ensure our project remains secure and stable, without introducing breaking changes.

### Changes

- Updated `h2` from `0.3.22` to `0.3.24` to fix [RUSTSEC-2024-0003](https://rustsec.org/advisories/RUSTSEC-2024-0003).
- Updated `mio` from `0.8.10` to `0.8.11` to fix [RUSTSEC-2024-0019](https://rustsec.org/advisories/RUSTSEC-2024-0019).
- Updated `whoami` from `1.4.1` to `1.5.0` to fix [RUSTSEC-2024-0020](https://rustsec.org/advisories/RUSTSEC-2024-0020).

### Testing

All updates have been tested by running `cargo test`, ensuring all existing tests pass without any issues. While comprehensive automated testing has been conducted, further manual testing and review are recommended to ensure that the updates do not affect application functionality.

### Additional Notes

These updates are critical for maintaining the security integrity of our project. As such, a detailed review and further manual testing are advisable before merging.

### Call to Action

I encourage the team to review these changes thoroughly. Please provide feedback or approval at your earliest convenience. Should any adjustments be required, I am ready to address them to ensure our project remains secure and functional.

Thank you for your attention to this important matter.